### PR TITLE
feat(gradle): add options to upload build artifacts

### DIFF
--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -43,6 +43,16 @@ on:
         default: "fail" # Fail on warnings
         type: string
         required: false
+      codecov_enabled:
+        description: "Whether test coverage should be uploaded to Codecov"
+        default: true
+        type: boolean
+        required: false
+      upload_artifacts:
+        description: "Artifacts to upload after building"
+        default: ""
+        type: string
+        required: false
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.event.number || github.ref }}"
@@ -103,6 +113,14 @@ jobs:
             **/build/reports/
 
       - name: "Upload coverage to Codecov"
+        if: inputs.codecov_enabled
         uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3
         with:
           fail_ci_if_error: false
+
+      - name: "Upload artifacts"
+        if: inputs.upload_artifacts != ''
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3
+        with:
+          if-no-files-found: ignore
+          path: "${{ inputs.upload_artifacts }}"

--- a/.github/workflows/gradle-release.yml
+++ b/.github/workflows/gradle-release.yml
@@ -47,6 +47,11 @@ on:
         default: false
         type: boolean
         required: false
+      release_files:
+        description: "Newline-delimited list of path globs to upload when creating GitHub release"
+        default: ""
+        type: string
+        required: false
     secrets:
       HYPERA_SIGNING_KEY:
         description: "Hypera Development GPG signing key"
@@ -68,7 +73,7 @@ on:
         required: false
       GITHUB_RELEASE_TOKEN:
         description: "GitHub token used to create release"
-        required: false
+        required: true
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
@@ -167,3 +172,4 @@ jobs:
           target_commitish: "${{ github.ref_name }}"
           generate_release_notes: true
           token: "${{ secrets.GITHUB_RELEASE_TOKEN }}"
+          files: "${{ inputs.release_files }}"


### PR DESCRIPTION
Add options to upload artifacts after build, and when creating a GitHub
release.

Additionally, add `codecov_enabled` option for the build workflow, that
can be set to `false` to prevent test coverage being uploaded to
Codecov.
