### PR TITLE
fix(go): only run lint on linux

### DIFF
--- a/.github/workflows/go-build.yml
+++ b/.github/workflows/go-build.yml
@@ -118,7 +118,7 @@ jobs:
         run: go mod verify
 
       - name: "Lint"
-        if: inputs.lint_enabled
+        if: inputs.lint_enabled && runner.os == 'Linux'
         uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3
         with:
           version: "latest"


### PR DESCRIPTION
Fixes golangci-lint causing the `go-build` workflow to fail on Windows when `lint_enabled: true`
