### PR TITLE
refactor(gradle): update Gradle actions, tidy up

### DIFF
--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -1,7 +1,7 @@
 #
 # This file is a part of HyperaDev/actions, licensed under the MIT License.
 #
-# Copyright (c) 2021-2023 Joshua Sing <joshua@hypera.dev>
+# Copyright (c) 2021-2024 Joshua Sing <joshua@hypera.dev>
 # Copyright (c) 2021-2023 LooFifteen <luis@lu15.dev>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -30,8 +30,8 @@ on:
     inputs:
       java_version:
         description: "JDK version to be used when building"
-        default: 11
-        type: number
+        default: "21" # Use latest JDK LTS.
+        type: string
         required: false
       gradle_extra_args:
         description: "Extra arguments to execute Gradle with"
@@ -45,7 +45,7 @@ on:
         required: false
       codecov_enabled:
         description: "Whether test coverage should be uploaded to Codecov"
-        default: true
+        default: false
         type: boolean
         required: false
       upload_artifacts:
@@ -62,20 +62,9 @@ permissions:
   contents: read
 
 jobs:
-  validate:
-    name: "Validate"
-    runs-on: "ubuntu-latest"
-    steps:
-      - name: "Checkout repository"
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
-
-      - name: "Validate Gradle wrapper"
-        uses: gradle/wrapper-validation-action@56b90f209b02bf6d1deae490e9ef18b21a389cd4 # v1
-
   build:
     name: "Build"
     runs-on: "ubuntu-latest"
-    needs: ["validate"]
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
@@ -83,11 +72,19 @@ jobs:
           fetch-depth: 0
           submodules: true
 
-      - name: "Set up JDK ${{ inputs.java_version }}"
+      - name: "Validate Gradle wrapper"
+        uses: gradle/wrapper-validation-action@27152f6fa06a6b8062ef7195c795692e51fc2c81 # v2
+
+      - name: "Setup JDK ${{ inputs.java_version }}"
         uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93 # v4
         with:
           java-version: "${{ inputs.java_version }}"
-          distribution: "temurin" # Adoptium
+          distribution: "temurin"
+
+      - name: "Setup Gradle"
+        uses: gradle/actions/setup-gradle@aff52e5be96935327d77c5529075184377dc4371 # v3
+        with:
+          gradle-version: "wrapper"
 
       - name: "Prepare for build"
         env:
@@ -98,10 +95,7 @@ jobs:
           echo "org.gradle.warning.mode=$WARNING_MODE" >> $HOME/.gradle/gradle.properties
 
       - name: "Build"
-        uses: gradle/gradle-build-action@a8f75513eafdebd8141bd1cd4e30fcd194af8dfa # v2
-        with:
-          gradle-version: "wrapper"
-          arguments: "${{ inputs.gradle_extra_args }} build"
+        run: ./gradlew ${{ inputs.gradle_extra_args }} build
 
       - name: "Archive test reports"
         if: always()
@@ -113,7 +107,7 @@ jobs:
             **/build/reports/
 
       - name: "Upload coverage to Codecov"
-        if: inputs.codecov_enabled
+        if: always() && inputs.codecov_enabled
         uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457 # v3
         with:
           fail_ci_if_error: false

--- a/.github/workflows/gradle-release.yml
+++ b/.github/workflows/gradle-release.yml
@@ -1,7 +1,7 @@
 #
 # This file is a part of HyperaDev/actions, licensed under the MIT License.
 #
-# Copyright (c) 2021-2023 Joshua Sing <joshua@hypera.dev>
+# Copyright (c) 2021-2024 Joshua Sing <joshua@hypera.dev>
 # Copyright (c) 2021-2023 LooFifteen <luis@lu15.dev>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -34,8 +34,8 @@ on:
         required: true
       java_version:
         description: "JDK version to be used when building"
-        default: 11
-        type: number
+        default: "21" # Use latest JDK LTS.
+        type: string
         required: false
       gradle_extra_args:
         description: "Extra arguments to execute Gradle with"
@@ -83,31 +83,29 @@ permissions:
   contents: read
 
 jobs:
-  validate:
-    name: "Validate"
-    runs-on: "ubuntu-latest"
-    steps:
-      - name: "Checkout repository"
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
-
-      - name: "Validate Gradle wrapper"
-        uses: gradle/wrapper-validation-action@56b90f209b02bf6d1deae490e9ef18b21a389cd4 # v1
-
   release:
     name: "Release"
     runs-on: "ubuntu-latest"
-    needs: ["validate"]
     environment:
       name: "release"
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
 
-      - name: "Set up JDK ${{ inputs.java_version }}"
+      - name: "Validate Gradle wrapper"
+        uses: gradle/wrapper-validation-action@27152f6fa06a6b8062ef7195c795692e51fc2c81 # v2
+
+      - name: "Setup JDK ${{ inputs.java_version }}"
         uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93 # v4
         with:
           java-version: "${{ inputs.java_version }}"
-          distribution: "temurin" # Adoptium
+          distribution: "temurin"
+
+      - name: "Setup Gradle"
+        uses: gradle/actions/setup-gradle@aff52e5be96935327d77c5529075184377dc4371 # v3
+        with:
+          gradle-version: "wrapper"
+          cache-write-only: true
 
       - name: "Validate version"
         id: version
@@ -143,9 +141,7 @@ jobs:
           git tag -a "v$VERSION" HEAD -m "v$VERSION"
 
       - name: "Publish artifacts"
-        uses: gradle/gradle-build-action@a8f75513eafdebd8141bd1cd4e30fcd194af8dfa # v2
-        with:
-          arguments: "${{ inputs.gradle_extra_args }} publish closeSonatypeStagingRepository"
+        run: ./gradlew ${{ inputs.gradle_extra_args }} publish closeSonatypeStagingRepository
         env:
           ORG_GRADLE_PROJECT_hyperaSigningKey: "${{ secrets.HYPERA_SIGNING_KEY }}"
           ORG_GRADLE_PROJECT_hyperaSigningPassword: "${{ secrets.HYPERA_SIGNING_PASSWORD }}"
@@ -156,9 +152,7 @@ jobs:
 
       - name: "Release to Maven Central"
         if: inputs.release_maven_central
-        uses: gradle/gradle-build-action@a8f75513eafdebd8141bd1cd4e30fcd194af8dfa # v2
-        with:
-          arguments: "findSonatypeStagingRepository releaseSonatypeStagingRepository"
+        run: ./gradlew findSonatypeStagingRepository releaseSonatypeStagingRepository
         env:
           ORG_GRADLE_PROJECT_sonatypeUsername: "${{ secrets.SONATYPE_USERNAME }}"
           ORG_GRADLE_PROJECT_sonatypePassword: "${{ secrets.SONATYPE_PASSWORD }}"

--- a/.github/workflows/gradle-snapshot.yml
+++ b/.github/workflows/gradle-snapshot.yml
@@ -1,7 +1,7 @@
 #
 # This file is a part of HyperaDev/actions, licensed under the MIT License.
 #
-# Copyright (c) 2021-2023 Joshua Sing <joshua@hypera.dev>
+# Copyright (c) 2021-2024 Joshua Sing <joshua@hypera.dev>
 # Copyright (c) 2021-2023 LooFifteen <luis@lu15.dev>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -30,8 +30,8 @@ on:
     inputs:
       java_version:
         description: "JDK version to be used when building"
-        default: 11
-        type: number
+        default: "21" # Use latest JDK LTS.
+        type: string
         required: false
       gradle_extra_args:
         description: "Extra arguments to execute Gradle with"
@@ -66,31 +66,28 @@ permissions:
   contents: read
 
 jobs:
-  validate:
-    name: "Validate"
+  publish:
+    name: "Publish"
     runs-on: "ubuntu-latest"
-    steps:
-      - name: "Checkout repository"
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
-
-      - name: "Validate Gradle wrapper"
-        uses: gradle/wrapper-validation-action@56b90f209b02bf6d1deae490e9ef18b21a389cd4 # v1
-
-  snapshot:
-    name: "Snapshot"
-    runs-on: "ubuntu-latest"
-    needs: ["validate"]
     environment:
       name: "snapshot"
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
 
-      - name: "Set up JDK ${{ inputs.java_version }}"
+      - name: "Validate Gradle wrapper"
+        uses: gradle/wrapper-validation-action@27152f6fa06a6b8062ef7195c795692e51fc2c81 # v2
+
+      - name: "Setup JDK ${{ inputs.java_version }}"
         uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93 # v4
         with:
           java-version: "${{ inputs.java_version }}"
-          distribution: "temurin" # Adoptium
+          distribution: "temurin"
+
+      - name: "Setup Gradle"
+        uses: gradle/actions/setup-gradle@aff52e5be96935327d77c5529075184377dc4371 # v3
+        with:
+          gradle-version: "wrapper"
 
       - name: "Validate version"
         run: |
@@ -100,17 +97,8 @@ jobs:
           fi
           echo "Snapshot version detected"
 
-      - name: "Prepare for publish"
-        run: |
-          # Git ignore dependency graph files (Indra cleanliness checks)
-          mkdir -p .git/info/
-          echo "/dependency-graph-reports/" >> .git/info/exclude
-
       - name: "Publish artifacts"
-        uses: gradle/gradle-build-action@a8f75513eafdebd8141bd1cd4e30fcd194af8dfa # v2
-        with:
-          dependency-graph: "generate"
-          arguments: "${{ inputs.gradle_extra_args }} publish"
+        run: ./gradlew ${{ inputs.gradle_extra_args }} publish
         env:
           ORG_GRADLE_PROJECT_hyperaSigningKey: "${{ secrets.HYPERA_SIGNING_KEY }}"
           ORG_GRADLE_PROJECT_hyperaSigningPassword: "${{ secrets.HYPERA_SIGNING_PASSWORD }}"
@@ -122,11 +110,14 @@ jobs:
   dependency-graph:
     name: "Dependency Graph"
     runs-on: "ubuntu-latest"
-    needs: ["snapshot"]
     permissions:
       contents: write
     steps:
-      - name: "Submit Dependency Graph"
-        uses: gradle/gradle-build-action@a8f75513eafdebd8141bd1cd4e30fcd194af8dfa # v2
-        with:
-          dependency-graph: "download-and-submit"
+      - name: "Checkout repository"
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+
+      - name: "Validate Gradle wrapper"
+        uses: gradle/wrapper-validation-action@27152f6fa06a6b8062ef7195c795692e51fc2c81 # v2
+
+      - name: "Generate and submit dependency graph"
+        uses: gradle/actions/dependency-submission@aff52e5be96935327d77c5529075184377dc4371 # v3

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021-2023 Joshua Sing <joshua@hypera.dev>
+Copyright (c) 2021-2024 Joshua Sing <joshua@hypera.dev>
 Copyright (c) 2021-2023 LooFifteen <luis@lu15.dev>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/workflow-templates/gradle-release.yml
+++ b/workflow-templates/gradle-release.yml
@@ -1,14 +1,25 @@
 # GitHub Actions workflow to publish releases.
 # Releases are published from the 'releases/<major>' branches.
-name: "Release"
+name: "Gradle"
 on:
   push:
     branches: [ "releases/**" ]
 
 jobs:
   release:
+    name: "Release"
     uses: HyperaDev/actions/.github/workflows/gradle-release.yml@main
-    secrets: "inherit"
     with:
       project_name: "Project" # TODO: replace with actual project name
-      release_maven_central: false
+      # java_version: "21"
+      # gradle_extra_args: ""
+      # release_maven_central: false
+      # release_files: ""
+    secrets:
+      # HYPERA_SIGNING_KEY: "${{ secrets.HYPERA_SIGNING_KEY }}"
+      # HYPERA_SIGNING_PASSWORD: "${{ secrets.HYPERA_SIGNING_PASSWORD }}"
+      # HYPERA_RELEASES_USERNAME: "${{ secrets.HYPERA_RELEASES_USERNAME }}"
+      # HYPERA_RELEASES_PASSWORD: "${{ secrets.HYPERA_RELEASES_PASSWORD }}"
+      # SONATYPE_USERNAME: "${{ secrets.SONATYPE_USERNAME }}"
+      # SONATYPE_PASSWORD: "${{ secrets.SONATYPE_PASSWORD }}"
+      GITHUB_RELEASE_TOKEN: "${{ secrets.GITHUB_RELEASE_TOKEN }}"

--- a/workflow-templates/gradle-snapshot.yml
+++ b/workflow-templates/gradle-snapshot.yml
@@ -1,12 +1,22 @@
 # GitHub Actions workflow to publish unstable snapshots.
 # Snapshots are published from the 'main' branch, and should always be considered
 # unstable and unfit for production usage.
-name: "Snapshot"
+name: "Gradle"
 on:
   push:
     branches: [ "main" ]
 
 jobs:
   snapshot:
+    name: "Snapshot"
     uses: HyperaDev/actions/.github/workflows/gradle-snapshot.yml@main
-    secrets: "inherit"
+    with:
+      # java_version: "21"
+      # gradle_extra_args: ""
+    secrets:
+      # HYPERA_SIGNING_KEY: "${{ secrets.HYPERA_SIGNING_KEY }}"
+      # HYPERA_SIGNING_PASSWORD: "${{ secrets.HYPERA_SIGNING_PASSWORD }}"
+      # HYPERA_SNAPSHOTS_USERNAME: "${{ secrets.HYPERA_SNAPSHOTS_USERNAME }}"
+      # HYPERA_SNAPSHOTS_PASSWORD: "${{ secrets.HYPERA_SNAPSHOTS_PASSWORD }}"
+      # SONATYPE_USERNAME: "${{ secrets.SONATYPE_USERNAME }}"
+      # SONATYPE_PASSWORD: "${{ secrets.SONATYPE_PASSWORD }}"

--- a/workflow-templates/gradle.yml
+++ b/workflow-templates/gradle.yml
@@ -2,7 +2,7 @@
 name: "Gradle"
 on:
   push:
-    branches: [ "main", "releases/**" ]
+    branches: [ "main" ]
     tags-ignore: ["**"]
   pull_request:
     branches: [ "main" ]
@@ -10,4 +10,11 @@ on:
 
 jobs:
   build:
+    name: "Build"
     uses: HyperaDev/actions/.github/workflows/gradle-build.yml@main
+    with:
+      # java_version: "21"
+      # gradle_extra_args: ""
+      # gradle_warning_mode: "fail"
+      # codecov_enabled: false
+      # upload_artifacts: ""


### PR DESCRIPTION
This pull request updates the Gradle workflows to use the new `gradle/actions` actions (fixes #22), and updates the `gradle/wrapper-validation-action` to `v2`.

This also does some tidy-up in the Gradle workflows and workflow templates, such as documenting the available inputs in the workflow templates, and moving wrapper validation into the jobs instead of having them in a separate job.