### PR TITLE
chore(deps): update codecov/codecov-action to v4

### DIFF
--- a/.github/workflows/go-build.yml
+++ b/.github/workflows/go-build.yml
@@ -43,6 +43,16 @@ on:
         default: false
         type: boolean
         required: false
+      codecov_files:
+        description: "Comma-separated paths to the coverage report(s)"
+        default: ""
+        type: string
+        required: false
+      codecov_directory:
+        description: "Directory to search for coverage reports in"
+        default: ""
+        type: string
+        required: false
       lint_enabled:
         description: "Whether to run golangci-lint"
         default: false
@@ -57,6 +67,10 @@ on:
         description: "Artifacts to upload after building"
         default: ""
         type: string
+        required: false
+    secrets:
+      CODECOV_TOKEN:
+        description: "Codecov repository upload token"
         required: false
 
 concurrency:
@@ -132,7 +146,14 @@ jobs:
 
       - name: "Upload coverage to Codecov"
         if: inputs.codecov_enabled && runner.os == 'Linux'
-        uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457 # v3
+        uses: codecov/codecov-action@f30e4959ba63075080d4f7f90cacc18d9f3fafd7 # v4.0.0
+        with:
+          files: "${{ inputs.codecov_files }}"
+          directory: "${{ inputs.codecov_directory }}"
+          fail_ci_if_error: false
+          verbose: true
+        env:
+          CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN }}"
 
       - name: "Upload artifacts"
         uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4

--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -48,10 +48,24 @@ on:
         default: false
         type: boolean
         required: false
+      codecov_files:
+        description: "Comma-separated paths to the coverage report(s)"
+        default: ""
+        type: string
+        required: false
+      codecov_directory:
+        description: "Directory to search for coverage reports in"
+        default: ""
+        type: string
+        required: false
       upload_artifacts:
         description: "Artifacts to upload after building"
         default: ""
         type: string
+        required: false
+    secrets:
+      CODECOV_TOKEN:
+        description: "Codecov repository upload token"
         required: false
 
 concurrency:
@@ -108,9 +122,14 @@ jobs:
 
       - name: "Upload coverage to Codecov"
         if: always() && inputs.codecov_enabled
-        uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457 # v3
+        uses: codecov/codecov-action@f30e4959ba63075080d4f7f90cacc18d9f3fafd7 # v4.0.0
         with:
+          files: "${{ inputs.codecov_files }}"
+          directory: "${{ inputs.codecov_directory }}"
           fail_ci_if_error: false
+          verbose: true
+        env:
+          CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN }}"
 
       - name: "Upload artifacts"
         if: inputs.upload_artifacts != ''

--- a/workflow-templates/go.yml
+++ b/workflow-templates/go.yml
@@ -15,6 +15,8 @@ jobs:
       # go_version: ""
       # go_build_args: ""
       # codecov_enabled: false
+      # codecov_files: ""
+      # codecov_directory: ""
       # lint_enabled: false
       # vulncheck_enabled: true
       # upload_artifacts: ""

--- a/workflow-templates/gradle.yml
+++ b/workflow-templates/gradle.yml
@@ -17,4 +17,6 @@ jobs:
       # gradle_extra_args: ""
       # gradle_warning_mode: "fail"
       # codecov_enabled: false
+      # codecov_files: ""
+      # codecov_directory: ""
       # upload_artifacts: ""


### PR DESCRIPTION
Update the `codecov/codecov-action` to `v4.0.0`.
Additionally, add `codecov_files` and `codecov_directory` inputs.

**`CODECOV_TOKEN` secret is now required when using Codecov.**
