### PR TITLE
refactor: remove concurrency groups from reusable workflows

### DIFF
--- a/.github/workflows/go-build.yml
+++ b/.github/workflows/go-build.yml
@@ -73,10 +73,6 @@ on:
         description: "Codecov repository upload token"
         required: false
 
-concurrency:
-  group: "${{ github.workflow }}-${{ github.event.number || github.ref }}"
-  cancel-in-progress: "${{ github.event.action != 'merge_group' }}"
-
 permissions:
   contents: read
 

--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -68,10 +68,6 @@ on:
         description: "Codecov repository upload token"
         required: false
 
-concurrency:
-  group: "${{ github.workflow }}-${{ github.event.number || github.ref }}"
-  cancel-in-progress: "${{ github.event.action != 'merge_group' }}"
-
 permissions:
   contents: read
 

--- a/.github/workflows/gradle-release.yml
+++ b/.github/workflows/gradle-release.yml
@@ -75,10 +75,6 @@ on:
         description: "GitHub token used to create release"
         required: true
 
-concurrency:
-  group: "${{ github.workflow }}-${{ github.ref }}"
-  cancel-in-progress: true
-
 permissions:
   contents: read
 

--- a/.github/workflows/gradle-snapshot.yml
+++ b/.github/workflows/gradle-snapshot.yml
@@ -58,10 +58,6 @@ on:
         description: "Sonatype OSSRH password"
         required: false
 
-concurrency:
-  group: "${{ github.workflow }}-${{ github.ref }}"
-  cancel-in-progress: true
-
 permissions:
   contents: read
 

--- a/workflow-templates/go-release.yml
+++ b/workflow-templates/go-release.yml
@@ -5,6 +5,9 @@ on:
   push:
     tags: [ "v*.*.*" ]
 
+concurrency:
+  group: "go-release-${{ github.ref }}"
+
 jobs:
   release:
     name: "Release"

--- a/workflow-templates/go.yml
+++ b/workflow-templates/go.yml
@@ -7,6 +7,10 @@ on:
     branches: [ "main" ]
   merge_group:
 
+concurrency:
+  group: "go-${{ github.event.number || github.ref }}"
+  cancel-in-progress: "${{ github.event.action != 'merge_group' }}"
+
 jobs:
   build:
     name: "Build"

--- a/workflow-templates/gradle-release.yml
+++ b/workflow-templates/gradle-release.yml
@@ -5,6 +5,10 @@ on:
   push:
     branches: [ "releases/**" ]
 
+concurrency:
+  group: "gradle-release-${{ github.ref }}"
+  cancel-in-progress: true
+
 jobs:
   release:
     name: "Release"

--- a/workflow-templates/gradle-snapshot.yml
+++ b/workflow-templates/gradle-snapshot.yml
@@ -6,6 +6,10 @@ on:
   push:
     branches: [ "main" ]
 
+concurrency:
+  group: "gradle-snapshot-${{ github.ref }}"
+  cancel-in-progress: true
+
 jobs:
   snapshot:
     name: "Snapshot"

--- a/workflow-templates/gradle.yml
+++ b/workflow-templates/gradle.yml
@@ -8,6 +8,10 @@ on:
     branches: [ "main" ]
   merge_group:
 
+concurrency:
+  group: "gradle-build-${{ github.event.number || github.ref }}"
+  cancel-in-progress: "${{ github.event.action != 'merge_group' }}"
+
 jobs:
   build:
     name: "Build"


### PR DESCRIPTION
Remove the concurrency groups from the reusable workflows.
This allows control of the concurrency groups outside of the reusable workflows.
