### PR TITLE
fix(gradle): use wrapper to retrieve version

### DIFF
--- a/.github/workflows/gradle-release.yml
+++ b/.github/workflows/gradle-release.yml
@@ -110,7 +110,7 @@ jobs:
         #  1.0.0 = stable, 1.1.0-rc.1 = unstable, 0.1.0 = unstable
         run: |
           # Extract version
-          VERSION="$(grep -oP '(?<=version = \").*(?=\")' build.gradle.kts)"
+          VERSION="$(./gradlew properties | awk '/^version:/ { print $2; }')"
           # Prevent releasing '-SNAPSHOT' versions
           if echo "$VERSION" | grep -q 'SNAPSHOT'; then
             echo "Detected snapshot version, refusing to release..."

--- a/.github/workflows/gradle-snapshot.yml
+++ b/.github/workflows/gradle-snapshot.yml
@@ -87,7 +87,8 @@ jobs:
 
       - name: "Validate version"
         run: |
-          if ! grep -q 'version = ".*-SNAPSHOT"' build.gradle.kts; then
+          VERSION="$(./gradlew properties | awk '/^version:/ { print $2; }')"
+          if ! echo "$VERSION" | grep -q 'SNAPSHOT'; then
             echo "Release version detected, refusing to publish..."
             exit 1
           fi


### PR DESCRIPTION
This updates the Gradle workflows to use the Gradle wrapper to retrieve the project version.
Previously, the version would be read from the `build.gradle.kts` file, and required this file to contain `version = "(version)"`.

This change allows projects using the Gradle Groovy DSL, or projects storing the version elsewhere to use the shared workflows.
