### PR TITLE
fix(gradle): fetch all git history during checkout

### DIFF
--- a/.github/workflows/gradle-release.yml
+++ b/.github/workflows/gradle-release.yml
@@ -87,6 +87,9 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          fetch-depth: 0
+          submodules: true
 
       - name: "Validate Gradle wrapper"
         uses: gradle/wrapper-validation-action@85cde3f5a1033b2adc2442631c24b530f1183a1a # v2.1.0

--- a/.github/workflows/gradle-snapshot.yml
+++ b/.github/workflows/gradle-snapshot.yml
@@ -70,6 +70,9 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          fetch-depth: 0
+          submodules: true
 
       - name: "Validate Gradle wrapper"
         uses: gradle/wrapper-validation-action@85cde3f5a1033b2adc2442631c24b530f1183a1a # v2.1.0
@@ -111,6 +114,9 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          fetch-depth: 0
+          submodules: true
 
       - name: "Validate Gradle wrapper"
         uses: gradle/wrapper-validation-action@85cde3f5a1033b2adc2442631c24b530f1183a1a # v2.1.0


### PR DESCRIPTION
Change all Gradle shared workflows to use `fetch-depth: 0` when using the `actions/checkout` action.
Previously, only the commit that triggered the workflow would be fetched.

This change results in all Git history for all branches and all tags being fetched, which can be useful for automatic versioning and other features.
More information: https://github.com/actions/checkout
