### PR TITLE
fix(gradle): add setup-java step to dep submission

### DIFF
--- a/.github/workflows/gradle-snapshot.yml
+++ b/.github/workflows/gradle-snapshot.yml
@@ -119,6 +119,12 @@ jobs:
           fetch-depth: 0
           submodules: true
 
+      - name: "Setup JDK ${{ inputs.java_version }}"
+        uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93 # v4.0.0
+        with:
+          java-version: "${{ inputs.java_version }}"
+          distribution: "temurin"
+
       - name: "Validate Gradle wrapper"
         uses: gradle/wrapper-validation-action@85cde3f5a1033b2adc2442631c24b530f1183a1a # v2.1.0
 


### PR DESCRIPTION
Add the `setup-java` step to the Dependency Graph job in the Gradle Snapshot workflow.
Previously, the default Java version would be used which can cause issues in some projects.
