### PR TITLE
fix(gradle-release): publishing when sonatype is not setup

### DIFF
--- a/.github/workflows/gradle-release.yml
+++ b/.github/workflows/gradle-release.yml
@@ -140,7 +140,7 @@ jobs:
           git tag -a "v$VERSION" HEAD -m "v$VERSION"
 
       - name: "Publish artifacts"
-        run: ./gradlew ${{ inputs.gradle_extra_args }} publish closeSonatypeStagingRepository
+        run: ./gradlew ${{ inputs.gradle_extra_args }} publish
         env:
           ORG_GRADLE_PROJECT_hyperaSigningKey: "${{ secrets.HYPERA_SIGNING_KEY }}"
           ORG_GRADLE_PROJECT_hyperaSigningPassword: "${{ secrets.HYPERA_SIGNING_PASSWORD }}"
@@ -151,7 +151,7 @@ jobs:
 
       - name: "Release to Maven Central"
         if: inputs.release_maven_central
-        run: ./gradlew findSonatypeStagingRepository releaseSonatypeStagingRepository
+        run: ./gradlew findSonatypeStagingRepository closeAndReleaseSonatypeStagingRepository
         env:
           ORG_GRADLE_PROJECT_sonatypeUsername: "${{ secrets.SONATYPE_USERNAME }}"
           ORG_GRADLE_PROJECT_sonatypePassword: "${{ secrets.SONATYPE_PASSWORD }}"


### PR DESCRIPTION
Fix publishing in `gradle-release` workflow when a Sonatype repository has not been setup (and the `closeSonatypeStagingRepository` task does not exist).
